### PR TITLE
feat: Create initial JIRA summary Chrome extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "JIRA Summary Viewer",
+  "version": "1.0",
+  "description": "Fetches and displays JIRA issue summaries.",
+  "permissions": [
+    "storage",
+    "http://example.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>JIRA Summary</title>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div>
+    <label for="jiraKey">JIRA Key:</label>
+    <input type="text" id="jiraKey" name="jiraKey">
+  </div>
+  <button id="getSummaryButton">Get Summary</button>
+  <div id="loadingMessage" style="display: none;">Creating summary...</div>
+  <div id="summaryDisplay"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const jiraKeyInput = document.getElementById('jiraKey');
+  const getSummaryButton = document.getElementById('getSummaryButton');
+  const loadingMessage = document.getElementById('loadingMessage');
+  const summaryDisplay = document.getElementById('summaryDisplay');
+
+  getSummaryButton.addEventListener('click', function () {
+    const jiraKey = jiraKeyInput.value.trim();
+
+    if (!jiraKey) {
+      summaryDisplay.textContent = 'Please enter a JIRA key.';
+      return;
+    }
+
+    loadingMessage.style.display = 'block';
+    summaryDisplay.textContent = ''; // Clear previous summary
+
+    fetch('http://example.com/jira/v1/summary', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ key: jiraKey }),
+    })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then(data => {
+        loadingMessage.style.display = 'none';
+        if (data && data.summary) {
+          typeWriterEffect(data.summary, summaryDisplay);
+        } else {
+          summaryDisplay.textContent = 'Failed to get summary or summary is empty.';
+          console.error('Invalid data structure from API:', data);
+        }
+      })
+      .catch(error => {
+        loadingMessage.style.display = 'none';
+        summaryDisplay.textContent = `Error: ${error.message}`;
+        console.error('Error fetching summary:', error);
+      });
+  });
+
+  function typeWriterEffect(text, element, delay = 25) {
+    let i = 0;
+    element.textContent = ''; // Clear content before typing
+    function type() {
+      if (i < text.length) {
+        element.textContent += text.charAt(i);
+        i++;
+        setTimeout(type, delay);
+      }
+    }
+    type();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,39 @@
+body {
+  font-family: sans-serif;
+  width: 300px; /* Adjust width as needed */
+  padding: 10px;
+}
+
+div {
+  margin-bottom: 10px;
+}
+
+label {
+  margin-right: 5px;
+}
+
+input[type="text"] {
+  width: calc(100% - 70px); /* Adjust based on label and button */
+  padding: 5px;
+  margin-bottom: 5px; /* Add some space below input */
+}
+
+button {
+  padding: 8px 15px;
+  cursor: pointer;
+}
+
+#loadingMessage {
+  color: #555;
+  font-style: italic;
+  margin-top: 10px;
+}
+
+#summaryDisplay {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ddd;
+  min-height: 50px;
+  white-space: pre-wrap; /* To respect newlines in summary */
+  word-wrap: break-word; /* To break long words */
+}


### PR DESCRIPTION
Adds a Chrome extension that allows you to input a JIRA key, fetches a summary from a (currently dummy) backend endpoint, and displays it in the extension popup.

Key features implemented:
- manifest.json for extension definition
- popup.html for the UI (input field, button, display areas)
- popup.js for event handling, API call, and typewriter display effect
- style.css for basic styling

The API endpoint http://example.com/jira/v1/summary is currently a placeholder and will result in an error, which is handled by displaying an error message.