### PR TITLE
fix: manifest.jsonのhost_permissionsとstorage権限を修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,10 @@
   "version": "1.0",
   "description": "Fetches and displays JIRA issue summaries.",
   "permissions": [
-    "storage",
-    "http://example.com/*"
+    "storage"
+  ],
+  "host_permissions": [
+    "http://localhost:8080/serap-be/*"
   ],
   "action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
- URLアクセスのため正しく `host_permissions` を使用
- `storage` 権限を維持
- ホスト権限を http://localhost:8080/serap-be/* に設定