### PR TITLE
Update JIRA summary API endpoint and request body structure.

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     let attempt = 0; // For 503 errors
 
     function doFetch(currentAttempt, retriedAfterHogeTop = false) {
-      const apiUrl = `http://localhost:8080/jira/v1/summary/${encodeURIComponent(jiraKey)}`;
+      const apiUrl = 'http://localhost:8080/hoge/api/jira-summary/';
 
       fetch(apiUrl, {
         method: 'POST',
@@ -13,7 +13,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           'Content-Type': 'application/json',
           'accept': 'application/json'
         },
-        body: JSON.stringify({ note: "全体の要約をお願いします。" }),
+        body: JSON.stringify({ jiraKey: jiraKey, note: "全体の要約をお願いします。" }),
         redirect: 'manual' // Key change: handle redirects manually
       })
       .then(response => {


### PR DESCRIPTION
This commit updates the integration with the JIRA summary API based on revised specifications:

- The API endpoint is changed from `http://localhost:8080/jira/v1/summary/[JIRA_KEY]` to `http://localhost:8080/hoge/api/jira-summary/`.
- The JIRA issue key is now sent as part of the JSON request body instead of a URL path parameter.
- The request body now includes `jiraKey` and `note` fields. The `note` field is set to "全体の要約をお願いします。".

The existing 302 redirect handling for authentication remains in place and functions correctly with the updated API structure.

Changes include:
- Modified `background.js` to:
    - Use the new fixed API URL: `http://localhost:8080/hoge/api/jira-summary/`.
    - Send a POST request with a JSON body: `{"jiraKey": "KEY", "note": "全体の要約をお願いします。"}`.