### PR TITLE
I externalized the API and authentication URLs into a new configurati…

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+importScripts('config.js');
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'GET_JIRA_SUMMARY') {
     const maxRetries = 1; // For 503 errors
@@ -5,7 +7,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // Pass message object to use message.jiraKey and message.authRetry
     function doFetch(message, currentAttempt, retriedAfterHogeTop = false) {
-      const apiUrl = 'http://localhost:8080/hoge/api/jira-summary/';
+      const apiUrl = API_CONFIG.jiraSummaryUrl;
 
       fetch(apiUrl, {
         method: 'POST',
@@ -34,7 +36,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 // This will then use response.text() or statusText to create an error message.
             } else {
                 console.log('JIRA Summary Extension: Received 401 (first attempt for this user action). Sending authUrl.');
-                sendResponse({ authUrl: 'http://localhost:8080/hoge/top', jiraKey: message.jiraKey });
+                sendResponse({ authUrl: API_CONFIG.authUrl, jiraKey: message.jiraKey });
                 return null; // Crucial: stop further processing here
             }
         }

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+// config.js
+const API_CONFIG = {
+  jiraSummaryUrl: 'http://localhost:8080/hoge/api/jira-summary/',
+  authUrl: 'http://localhost:8080/hoge/top'
+};


### PR DESCRIPTION
…on file.

Specifically, I moved the JIRA summary API URL and the authentication URL into a new `config.js` file. This will make it easier for you to change these URLs in the future without needing to modify the core logic of your code.

Here's a summary of the changes I made:
- I created a new file named `config.js` and defined `API_CONFIG.jiraSummaryUrl` and `API_CONFIG.authUrl` within it.
- I modified your `background.js` file (which I understand is the service worker for Manifest V3):
    - I added `importScripts('config.js');` at the top to ensure the configuration is loaded.
    - I updated the API call to use `API_CONFIG.jiraSummaryUrl`.
    - I updated the authentication prompt logic to use `API_CONFIG.authUrl` when sending information to `content.js`.
- I also checked `content.js` to ensure there were no hardcoded instances of these URLs remaining.