### PR TITLE
I've updated the general API error messages to be more user-friendly.

### DIFF
--- a/background.js
+++ b/background.js
@@ -73,12 +73,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           sendResponse({ summary: data.data });
         } else {
           console.error('JIRA Summary Extension: Unexpected data structure from API (expected data.data):', data);
-          sendResponse({ error: 'APIから予期しないデータ形式（data.dataが見つかりません）で応答がありました。' });
+          const originalErrorDetails = 'APIの応答データ形式が予期されたものではありません。';
+          const userMessage = `エラーが発生しました。しばらく時間をおいてから再度お試しください。(詳細: ${originalErrorDetails})`;
+          sendResponse({ error: userMessage });
         }
       })
       .catch(error => {
         console.error('JIRA Summary Extension: Fetch error or other unhandled promise rejection:', error && error.message ? error.message : String(error));
-        sendResponse({ error: (error && error.message) || '不明なエラーが発生しました。' });
+        const originalErrorDetails = (error && error.message) || '不明なエラー';
+        const userMessage = `エラーが発生しました。しばらく時間をおいてから再度お試しください。(詳細: ${originalErrorDetails})`;
+        sendResponse({ error: userMessage });
       });
     }
 


### PR DESCRIPTION
I modified the error messages displayed to you for general API failures (e.g., network issues, server errors like 500/503, unexpected data format).

Changes:
- In `background.js`:
  - I updated the construction of error messages sent to `content.js` for general API errors.
  - The new messages are in Japanese and advise you to "wait a while and try again," while still including details of the original error.
  - This affects errors caught in the main error handling paths within `doFetch`.
- I verified that `content.js` will display these new pre-formatted error strings correctly using its existing `displayError` function.

This change does not affect the specific 401 authentication error messages that prompt for login.