### PR TITLE
feat: JIRAサマリーボタンの表示位置調整と動的更新対応

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,3 +64,7 @@
 #jiraSummaryDisplay strong {
   font-weight: bold;
 }
+
+#opsbar-jira\.issue\.tools > #jiraSummaryExtensionButton:first-child {
+  margin-left: 0;
+}


### PR DESCRIPTION
JIRAの課題ページにおいて、サマリー表示ボタンの利便性を向上させるための以下の改修を実施しました。

- URLクエリパラメータ `filter` の有無に応じて、ボタンの表示位置を動的に変更する機能を追加しました。
    - `filter` が存在する場合: ボタンを `opsbar-jira.issue.tools` の左端に表示します。
    - `filter` が存在しない場合: ボタンを従来の `jira-share-trigger` の前に表示します。
- `MutationObserver` を導入し、フィルタービューなどでJIRAの課題内容がページ全体のリロードなしに動的に更新された場合でも、サマリーボタンが新しい課題に対して正しい位置に再表示され、機能するように対応しました。
- APIから503エラーが返却された際に、時間をおいて再試行を促す専用のエラーメッセージをあなたに表示するように改善しました。
- 上記変更に伴い、関連するCSSの調整も行いました。